### PR TITLE
v0.15.3.3-rc2 - Storage #for functions, Radar Overlays off when debugging

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,11 +17,11 @@ parchment_mappings_version=2024.11.17
 mod_id=pmweatherapi
 mod_name=PMWeatherAPI
 mod_license=GNU GPL 3.0
-mod_version=0.15.3.3-rc1
+mod_version=0.15.3.3-rc2
 mod_group_id=net.nullved
 mod_authors=nullved
 mod_description=An API for interfacing with ProtoManly's Weather Mod
 
 # Dependencies
 pmweather_version=0.15.3
-pmweather_version_range=[0.15.0-1.21.1-alpha,0.15.999-1.21.1-alpha)
+pmweather_version_range=[0.15.3-1.21.1-alpha,0.15.999-1.21.1-alpha)

--- a/src/main/java/net/nullved/pmweatherapi/client/render/IDOverlay.java
+++ b/src/main/java/net/nullved/pmweatherapi/client/render/IDOverlay.java
@@ -37,9 +37,13 @@ public class IDOverlay implements IRadarOverlay {
         poseStack.pushPose();
         poseStack.translate((side.x * scale) - 0.5F * (scale - 1), 1.055f, (side.z * scale) - 0.5F * (scale - 1));
         poseStack.mulPose(Axis.YN.rotationDegrees(side.rotation));
+        poseStack.mulPose(Axis.XP.rotationDegrees(90));
         poseStack.scale(0.01f, 0.01f, 0.01f);
 
         renderText(Component.literal(mode.getId().toString()), renderData, poseStack);
+
+        poseStack.mulPose(Axis.XP.rotationDegrees(-90));
+
 
         float lineHeight = 8.0f;
         float offset = lineHeight;
@@ -47,6 +51,7 @@ public class IDOverlay implements IRadarOverlay {
             poseStack.pushPose();
             poseStack.translate(0, 0, offset);
             poseStack.scale(0.6f, 0.6f, 0.6f);
+            poseStack.mulPose(Axis.XP.rotationDegrees(90));
 
             renderText(Component.literal(overlay.get().getID().toString()).withColor(0x888888), renderData, poseStack);
 

--- a/src/main/java/net/nullved/pmweatherapi/config/PMWClientConfig.java
+++ b/src/main/java/net/nullved/pmweatherapi/config/PMWClientConfig.java
@@ -14,6 +14,8 @@ public class PMWClientConfig {
 
     private static final ModConfigSpec.BooleanValue DISABLE_CUSTOM_RADAR_MODE_RENDERING;
     public static boolean disableCustomRadarModeRendering;
+    private static final ModConfigSpec.BooleanValue DISABLE_OVERLAYS_WHEN_DEBUGGING;
+    public static boolean disableOverlaysWhenDebugging;
     private static final ModConfigSpec.BooleanValue SHOW_RADAR_MODE_ID;
     public static boolean showRadarModeId;
     private static final ModConfigSpec.EnumValue<RadarModeIDSide> RADAR_MODE_ID_SIDE;
@@ -25,6 +27,7 @@ public class PMWClientConfig {
         if (event.getConfig().getSpec() == SPEC && !(event instanceof ModConfigEvent.Unloading)) {
             PMWeatherAPI.LOGGER.info("Loading Client PMWeatherAPI Configs");
             disableCustomRadarModeRendering = DISABLE_CUSTOM_RADAR_MODE_RENDERING.getAsBoolean();
+            disableOverlaysWhenDebugging = DISABLE_OVERLAYS_WHEN_DEBUGGING.getAsBoolean();
             showRadarModeId = SHOW_RADAR_MODE_ID.getAsBoolean();
             radarModeIDSide = RADAR_MODE_ID_SIDE.get();
         }
@@ -32,6 +35,7 @@ public class PMWClientConfig {
 
     static {
         DISABLE_CUSTOM_RADAR_MODE_RENDERING = BUILDER.comment("Disables custom radar mode rendering").define("disable_custom_radar_mode_rendering", false);
+        DISABLE_OVERLAYS_WHEN_DEBUGGING = BUILDER.comment("Disables all overlays when client radar debugging is on").define("disable_overlays_when_debugging", true);
         SHOW_RADAR_MODE_ID = BUILDER.comment("Shows the radar mode ID").define("show_radar_mode_id", false);
         RADAR_MODE_ID_SIDE = BUILDER.comment("The side to render the radar mode ID on").defineEnum("radar_mode_id_side", RadarModeIDSide.NORTH);
         SPEC = BUILDER.build();

--- a/src/main/java/net/nullved/pmweatherapi/mixin/BlockBehaviourMixin.java
+++ b/src/main/java/net/nullved/pmweatherapi/mixin/BlockBehaviourMixin.java
@@ -33,7 +33,7 @@ public class BlockBehaviourMixin {
     private static void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean movedByPiston, CallbackInfo ci) {
         if (state.getBlock() instanceof RadarBlock) {
             RadarServerStorage radarStorage = PMWStorages.radars().get(level.dimension());
-            radarStorage.addAndSync(new RadarStorageData(pos, state.getValue(PMWExtras.RADAR_MODE)));
+            radarStorage.addAndSync(new RadarStorageData(pos, state.getValue(PMWExtras.RADAR_MODE), state.getValue(RadarBlock.ON)));
         } else if (state.getBlock() instanceof MetarBlock) {
             // Get Metar data
             WeatherHandler weatherHandler = GameBusEvents.MANAGERS.get(level.dimension());

--- a/src/main/java/net/nullved/pmweatherapi/mixin/RadarBlockMixin.java
+++ b/src/main/java/net/nullved/pmweatherapi/mixin/RadarBlockMixin.java
@@ -51,7 +51,7 @@ public class RadarBlockMixin {
         if (!level.isClientSide()) {
             RadarMode currentMode = state.getValue(PMWExtras.RADAR_MODE);
             RadarMode newMode = currentMode.cycle();
-            PMWStorages.radars().get(level.dimension()).addAndSync(new RadarStorageData(pos, newMode));
+            PMWStorages.radars().get(level.dimension()).addAndSync(new RadarStorageData(pos, newMode, state.getValue(RadarBlock.ON)));
             level.setBlockAndUpdate(pos, state.setValue(PMWExtras.RADAR_MODE, newMode));
         }
 

--- a/src/main/java/net/nullved/pmweatherapi/mixin/RadarRendererMixin.java
+++ b/src/main/java/net/nullved/pmweatherapi/mixin/RadarRendererMixin.java
@@ -592,7 +592,7 @@ public class RadarRendererMixin {
         bufferBuilder.addVertex(topLeft).setColor(color).addVertex(bottomLeft).setColor(color).addVertex(bottomRight).setColor(color).addVertex(topRight).setColor(color);
 
         // PMWeatherAPI: RadarOverlays callback
-        RadarOverlays.renderOverlays(renderData, bufferBuilder, canRender);
+        if (!ClientConfig.radarDebugging || !PMWClientConfig.disableOverlaysWhenDebugging) RadarOverlays.renderOverlays(renderData, bufferBuilder, canRender);
 
         matrix4fStack.mul(poseStack.last().pose().invert());
         matrix4fStack.translate(-0.5F, -1.05F, -0.5F);

--- a/src/main/java/net/nullved/pmweatherapi/radar/storage/RadarStorageData.java
+++ b/src/main/java/net/nullved/pmweatherapi/radar/storage/RadarStorageData.java
@@ -18,11 +18,21 @@ import net.nullved.pmweatherapi.storage.data.StorageData;
  */
 public class RadarStorageData extends StorageData {
     public static final ResourceLocation ID = PMWeatherAPI.rl("radar");
-    private RadarMode radarMode;
+    private final RadarMode radarMode;
+    private final boolean on;
 
-    public RadarStorageData(BlockPos pos, RadarMode radarMode) {
+    public RadarStorageData(BlockPos pos, RadarMode radarMode, boolean on) {
         super(pos);
         this.radarMode = radarMode;
+        this.on = on;
+    }
+
+    public RadarMode getRadarMode() {
+        return radarMode;
+    }
+
+    public boolean isOn() {
+        return on;
     }
 
     @Override
@@ -34,6 +44,7 @@ public class RadarStorageData extends StorageData {
     public CompoundTag serializeToNBT() {
         CompoundTag tag = super.serializeToNBT();
         tag.putString("radar_mode", radarMode.getSerializedName());
+        tag.putBoolean("on", on);
         return tag;
     }
 
@@ -42,9 +53,10 @@ public class RadarStorageData extends StorageData {
 
         if (bp != null) {
             RadarMode mode = RadarMode.get(tag.getString("radar_mode"));
-            return new RadarStorageData(bp, mode);
+            boolean on = tag.getBoolean("on");
+            return new RadarStorageData(bp, mode, on);
         } else {
-            return new RadarStorageData(NbtUtils.readBlockPos(tag, "").orElseThrow(() -> new IllegalArgumentException("Could not read BlockPos in RadarStorageData!")), RadarMode.get(tag.getString("radar_mode")));
+            return new RadarStorageData(NbtUtils.readBlockPos(tag, "").orElseThrow(() -> new IllegalArgumentException("Could not read BlockPos in RadarStorageData!")), RadarMode.get(tag.getString("radar_mode")), !tag.contains("on") || tag.getBoolean("on"));
         }
     }
 }

--- a/src/main/java/net/nullved/pmweatherapi/storage/IStorage.java
+++ b/src/main/java/net/nullved/pmweatherapi/storage/IStorage.java
@@ -12,6 +12,7 @@ import net.nullved.pmweatherapi.storage.data.StorageData;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * The interface defining a Storage such as {@link RadarStorage}
@@ -40,6 +41,11 @@ public interface IStorage<D extends IStorageData> {
     Set<D> getAllWithinRange(BlockPos base, double radius);
     Set<D> getInChunk(ChunkPos pos);
     Set<D> getInAdjacentChunks(ChunkPos pos);
+
+    void forAll(Consumer<D> consumer);
+    void forAllWithinRange(BlockPos base, double radius, Consumer<D> consumer);
+    void forInChunk(ChunkPos pos, Consumer<D> consumer);
+    void forInAdjacentChunks(ChunkPos pos, Consumer<D> consumer);
 
     boolean shouldRecalculate(ChunkPos pos);
 

--- a/src/main/java/net/nullved/pmweatherapi/storage/PMWStorage.java
+++ b/src/main/java/net/nullved/pmweatherapi/storage/PMWStorage.java
@@ -11,7 +11,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.event.level.ChunkWatchEvent;
 import net.nullved.pmweatherapi.PMWeatherAPI;
 import net.nullved.pmweatherapi.client.data.IClientStorage;
@@ -26,6 +25,7 @@ import net.nullved.pmweatherapi.storage.data.IStorageData;
 import net.nullved.pmweatherapi.storage.data.StorageData;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -127,6 +127,14 @@ public abstract class PMWStorage<D extends StorageData> implements IStorage<D> {
         return data.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
     }
 
+    /**
+     * Gets a {@link Set} of every {@link IStorageData} within a given radius of the base {@link BlockPos}
+     *
+     * @param base The base {@link BlockPos}
+     * @param radius The radius of the search range
+     * @return All {@link IStorageData} within {@code radius} blocks of the base {@link BlockPos}
+     * @since 0.15.3.3
+     */
     @Override
     public Set<D> getAllWithinRange(BlockPos base, double radius) {
         int chunks = (int) Math.ceil(radius / 16.0F) + 1;
@@ -155,6 +163,13 @@ public abstract class PMWStorage<D extends StorageData> implements IStorage<D> {
         return data.getOrDefault(pos, Set.of());
     }
 
+    /**
+     * Gets the {@link Set} of {@link IStorageData} within this and adjacent {@link ChunkPos}'
+     *
+     * @param pos The middle {@link ChunkPos}
+     * @return A {@link Set} of the {@link IStorageData} in this and adjacent chunks
+     * @since 0.15.3.3
+     */
     @Override
     public Set<D> getInAdjacentChunks(ChunkPos pos) {
         Set<D> set = new HashSet<>();
@@ -164,6 +179,55 @@ public abstract class PMWStorage<D extends StorageData> implements IStorage<D> {
             }
         }
         return set;
+    }
+
+
+    /**
+     * Executes a {@link Consumer} for every {@link IStorageData} saved in this {@link IStorage}, regardless of {@link ChunkPos}
+     *
+     * @param consumer The function to run for each {@link IStorageData}
+     * @since 0.15.3.3-rc2
+     */
+    @Override
+    public void forAll(Consumer<D> consumer) {
+        getAll().forEach(consumer);
+    }
+
+    /**
+     * Executes a {@link Consumer} for every {@link IStorageData} within a given radius of the base {@link BlockPos}
+     *
+     * @param base The base {@link BlockPos}
+     * @param radius The radius of the search range
+     * @param consumer The function to run for each {@link IStorageData}
+     * @since 0.15.3.3-rc2
+     */
+    @Override
+    public void forAllWithinRange(BlockPos base, double radius, Consumer<D> consumer) {
+        getAllWithinRange(base, radius).forEach(consumer);
+    }
+
+    /**
+     * Executes a {@link Consumer} for each {@link IStorageData} in this {@link ChunkPos}
+     *
+     * @param pos The {@link ChunkPos} to search
+     * @param consumer The function to run for each {@link IStorageData}
+     * @since 0.15.3.3-rc2
+     */
+    @Override
+    public void forInChunk(ChunkPos pos, Consumer<D> consumer) {
+        getInChunk(pos).forEach(consumer);
+    }
+
+    /**
+     * Executes a {@link Consumer} for each {@link IStorageData} within this and adjacent {@link ChunkPos}'
+     *
+     * @param pos The middle {@link ChunkPos}
+     * @param consumer The function to run for each {@link IStorageData}
+     * @since 0.15.3.3-rc2
+     */
+    @Override
+    public void forInAdjacentChunks(ChunkPos pos, Consumer<D> consumer) {
+        getInAdjacentChunks(pos).forEach(consumer);
     }
 
     /**

--- a/src/main/resources/assets/pmweatherapi/lang/en_us.json
+++ b/src/main/resources/assets/pmweatherapi/lang/en_us.json
@@ -1,6 +1,8 @@
 {
   "pmweatherapi.configuration.disable_custom_radar_mode_rendering": "Disable Custom Radar Mode Rendering",
   "pmweatherapi.configuration.disable_custom_radar_mode_rendering.tooltip": "Disables all custom radar modes from rendering. Falls back to PMWeather for Reflectivity and Velocity. Any custom radar modes will not appear, but still be cycled through",
+  "pmweatherapi.configuration.disable_overlays_when_debugging": "Disable Overlays when Debugging",
+  "pmweatherapi.configuration.disable_overlays_when_debugging.tooltip": "Disables all overlays from rendering when client radar debugging is on",
   "pmweatherapi.configuration.show_radar_mode_id": "Show Radar Mode ID",
   "pmweatherapi.configuration.show_radar_mode_id.tooltip": "Enables an overlay to show the current radar mode's ID",
   "pmweatherapi.configuration.radar_mode_id_side": "Radar Mode ID Side",


### PR DESCRIPTION
- Added a client setting to disable radar overlays when the radar is in debugging mode. On by default
- Added IStorage#forAll, IStorage#forAllWithinRange, IStorage#forInChunk, IStorage#forInAdjacentChunks
- Added 'on' property to RadarStorageData
- Fixed ID overlay